### PR TITLE
Added "main" key into package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "A plug-in for the Leaflet map library to define patterns (like dashes, arrows, icons, etc.) on Polylines",
   "keywords": ["leaflet", "map", "polyline", "decorator", "patterns", "overlay"],
   "version": "0.7.2",
+  "main": "leaflet.polylineDecorator.js",
   "repository": "bbecquet/Leaflet.PolylineDecorator",
   "license": "MIT"
 }


### PR DESCRIPTION
Hey,

I got some troubleshooting including the lib into my project (es6, webpack), using React.js/Redux and react-leaflet, because it was missing the "main" key into the .

This fix permits to load the library directly with an import :)

Hope you will merge it soon :)